### PR TITLE
Change default config to DebugConfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ osd_dir = $(base_dir)/opensocdebug/hardware
 
 project_name = lowrisc-chip-imp
 BACKEND ?= lowrisc_chip.LowRISCBackend
-#CONFIG ?= Nexys4DebugConfig
-CONFIG ?= Nexys4Config
+CONFIG ?= Nexys4DebugConfig
+#CONFIG ?= Nexys4Config
 
 VIVADO = vivado
 


### PR DESCRIPTION
It is required to run make cleanall to update the vivado project and
other artifacts.
