### PR TITLE
Rely on $XILINX_VIVADO env var to find vivado binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BACKEND ?= lowrisc_chip.LowRISCBackend
 CONFIG ?= Nexys4DebugConfig
 #CONFIG ?= Nexys4Config
 
-VIVADO = vivado
+VIVADO = $(XILINX_VIVADO)/bin/vivado
 
 include $(base_dir)/Makefrag
 


### PR DESCRIPTION
If there are several versions of Vivado installed, a user might
set $XILINX_VIVADO to one installation, while having another in
$PATH. This ensures only the one defined by $XILINX_VIVADO is used